### PR TITLE
Improve Active Monitoring - add date header in email notifications

### DIFF
--- a/seefusion-main/src/main/java/com/seefusion/ActiveMonitoringRule.java
+++ b/seefusion-main/src/main/java/com/seefusion/ActiveMonitoringRule.java
@@ -613,6 +613,7 @@ abstract class ActiveMonitoringRule {
 		}
 		// do notify
 		SmtpMessage msg = new SmtpMessage();
+		msg.setSmtpDate();
 		msg.setSmtpFrom(this.smtpFrom);
 		msg.setSmtpTo(this.smtpTo);
 		msg.setContentType("text/html; charset=\"UTF-8\"");

--- a/seefusion-main/src/main/java/com/seefusion/SmtpMessage.java
+++ b/seefusion-main/src/main/java/com/seefusion/SmtpMessage.java
@@ -3,11 +3,19 @@
  */
 package com.seefusion;
 
+import java.util.TimeZone;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
 /**
  * @author Daryl
  *
  */
 class SmtpMessage {
+
+	String smtpDate;
 
 	String smtpFrom;
 	
@@ -118,5 +126,22 @@ class SmtpMessage {
 		this.contentType = contentType;
 	}
 
+	/**
+	 * @return Returns the smtpDate.
+	 */
+	String getSmtpDate() {
+		return this.smtpDate;
+	}
+
+	/**
+	 * @param smtpDate The smtpDate to set.
+	 */
+	void setSmtpDate(String smtpDate) {
+		TimeZone serverTimeZone = TimeZone.getDefault();
+		ZoneId serverZoneId = serverTimeZone.toZoneId();
+		ZonedDateTime currentTimeInServerZone = ZonedDateTime.now(serverZoneId);
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH);
+		this.smtpDate = currentTimeInServerZone.format(formatter);
+	}
 	
 }

--- a/seefusion-main/src/main/java/com/seefusion/SmtpSender.java
+++ b/seefusion-main/src/main/java/com/seefusion/SmtpSender.java
@@ -225,6 +225,7 @@ class SmtpSender extends SeeTask {
 		}
 
 		// send message
+		out.print("Date: " + message.smtpDate + CRLF);
 		out.print("From: " + message.smtpFrom + CRLF);
 		out.print("To: " + message.smtpTo + CRLF);
 		out.print("Subject: " + message.smtpSubject + CRLF);


### PR DESCRIPTION
The emails don't have a Date header, so Thunderbird for example displays the time at which it receives each email, which is often much later than when it was sent. So I added the Date header!